### PR TITLE
Wrapped ETag value within double quotes - RFC2616 - 14.19 & 3.11

### DIFF
--- a/lib/response-send.js
+++ b/lib/response-send.js
@@ -85,7 +85,7 @@ exports = module.exports = function(body){
     var etag = String(Buffer.isBuffer(body)
       ? crc.buffer.crc32(body)
       : crc.crc32(body));
-    if (!this.getHeader('ETag')) this.setHeader('ETag', etag);
+    if (!this.getHeader('ETag')) this.setHeader('ETag', '"' + etag + '"');
   }
 
   // determine if it's cacheable

--- a/test/send.js
+++ b/test/send.js
@@ -3,7 +3,8 @@ var http = require('http')
   , send = require('..')
   , server = http.createServer
   , request = require('supertest')
-  , pending = require('./utils/pending');
+  , pending = require('./utils/pending')
+  , should = require('should');
 
 // #nodejsWTF?
 
@@ -63,17 +64,17 @@ describe('res.send()', function(){
 
     request(app)
     .get('/foo')
-    .expect('ETag', '601152967')
+    .expect('ETag', '"601152967"')
     .end(done);
 
     request(app)
     .get('/foo')
-    .expect('ETag', '601152967')
+    .expect('ETag', '"601152967"')
     .end(done);
 
     request(app)
     .get('/bar')
-    .expect('ETag', '-1124164645')
+    .expect('ETag', '"-1124164645"')
     .end(done);
   })
 
@@ -86,12 +87,12 @@ describe('res.send()', function(){
 
     request(app)
     .get('/foo')
-    .expect('ETag', '601152967')
+    .expect('ETag', '"601152967"')
     .expect(200, done);
 
     request(app)
     .get('/foo')
-    .set('If-None-Match', '601152967')
+    .set('If-None-Match', '"601152967"')
     .end(function(err, res){
       res.should.have.status(304);
       res.headers.should.not.have.property('content-length');
@@ -111,12 +112,12 @@ describe('res.send()', function(){
 
     request(app)
     .get('/foo')
-    .expect('ETag', '601152967')
+    .expect('ETag', '"601152967"')
     .expect(500, done);
 
     request(app)
     .get('/foo')
-    .set('If-None-Match', '601152967')
+    .set('If-None-Match', '"601152967"')
     .end(function(err, res){
       res.should.have.status(500);
       res.headers.should.have.property('content-length');


### PR DESCRIPTION
As per RFC2616, section 3.11, entity tag value should be a quoted string. This PR fixes that.

```
      entity-tag = [ weak ] opaque-tag
      weak       = "W/"
      opaque-tag = quoted-string
```
